### PR TITLE
Default values for theme_name and theme_path options

### DIFF
--- a/wordless/admin.php
+++ b/wordless/admin.php
@@ -51,11 +51,13 @@ class WordlessAdmin
     $theme_options = array(
       "theme_name" => array(
         "label" => "Theme Name",
-        "description" => "This will be the name displayed inside Wordpress."
+        "description" => "This will be the name displayed inside Wordpress.",
+        "default_value" => "Wordless"
       ),
       "theme_path" => array(
         "label" => "Theme Directory",
-        "description" => "Specify the <code>wp-content/themes</code> subdirectory name for this theme."
+        "description" => "Specify the <code>wp-content/themes</code> subdirectory name for this theme.",
+        "default_value" => "wordless"
       ),
       "chmod_set" => array(
         "label" => "Permissions",


### PR DESCRIPTION
removes "index not found" errors inside the new wordless theme option page text fields when creating a new wordless theme.
