### PR TITLE
Correct "Wordpress" to "WordPress" in docs and code comments

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,9 +1,9 @@
 ![Wordless logo](http://welaika.github.com/wordless/assets/images/wordless.png)
 
-Wordless is an opinionated Wordpress plugin that dramatically speeds up and enhances your custom themes creation. Some of its features are:
+Wordless is an opinionated WordPress plugin that dramatically speeds up and enhances your custom themes creation. Some of its features are:
 
 * A structured, organized and clean [theme organization](https://github.com/welaika/wordless/tree/master/wordless/theme_builder/vanilla_theme) (taken directly from Rails);
-* Ability to create a new theme skeleton directly within the Wordpress backend interface;
+* Ability to create a new theme skeleton directly within the WordPress backend interface;
 * Ability to write PHP code using the beautiful [Haml templating system](http://haml-lang.com/);
 * Ability to write CSS stylesheets using the awesome [Sass syntax](sass-lang.com) and the [Compass framework](http://compass-style.org/);
 * Ability to write Javascript logic in [Coffeescript](http://jashkenas.github.com/coffee-script/);
@@ -14,7 +14,7 @@ Wordless is an opinionated Wordpress plugin that dramatically speeds up and enha
 
 1. Your development machine needs a ruby environment, and the [compass](https://github.com/chriseppstein/compass), [sprockets](https://github.com/sstephenson/sprockets) and [coffee-script](https://github.com/josh/ruby-coffee-script) gem. The `coffee-script` gem requires a valid javascript runtime available on your machine, see the [ExecJS readme](https://github.com/sstephenson/execjs/blob/master/README.md) to learn the supported ones;
 2. The production server doesn't need any extra-dependencies, as all the assets get pre-compiled by Wordless on the development machine and statically served;
-3. Enable Apache `mod_rewrite` module (`a2enmod rewrite`) and make sure Wordpress nice permalinks are enabled under the WP "Settings > Permalinks" section;
+3. Enable Apache `mod_rewrite` module (`a2enmod rewrite`) and make sure WordPress nice permalinks are enabled under the WP "Settings > Permalinks" section;
 4. [Download the Wordless plugin](https://github.com/welaika/wordless/zipball/master), drop it in the `wp-content/plugins` directory and enable it from the WP "Plugins" section;
 5. Create a brand new Wordless theme directly within the WP backend, from the WP "Appearance > New Wordless Theme" section;
 6. Specify the path of the `compass` and `ruby` executables within the `config/initializers/wordless_preferences.php` config file.
@@ -74,12 +74,12 @@ if (is_front_page()) {
   render_view("portfolio/show");
 }
 ```
-As you can see, you first determine the type of the page using [Wordpress conditional tags](http://codex.wordpress.org/Conditional_Tags), and then delegate the rendering to some particular view.
+As you can see, you first determine the type of the page using [WordPress conditional tags](http://codex.wordpress.org/Conditional_Tags), and then delegate the rendering to some particular view.
 
 ### Theme Views (`theme/views/*.haml`)
 
 That's the directory where you'll find yourself coding for most of the time. Here you can create a view for each main page of your theme, using Haml syntax.
-Feel free to create subdirectories to group toghether the files. Here's what could be an example for the typical [Wordpress loop](http://codex.wordpress.org/The_Loop) in an archive page:
+Feel free to create subdirectories to group toghether the files. Here's what could be an example for the typical [WordPress loop](http://codex.wordpress.org/The_Loop) in an archive page:
 
 ```haml
 / theme/views/posts/archive.haml
@@ -166,7 +166,7 @@ Just drop all your theme locale files in this directory. Wordless will take care
 <a name="assets"></a>
 ### Assets
 
-Wordpress has to different places where you want to put your assets:
+WordPress has to different places where you want to put your assets:
 
 * Place all the static images and vendor assets (i.e. jQuery and vendor JS plugins) into the `assets/*` directory;
 * Place all your custom, project related assets into the `theme/assets/*`.
@@ -216,11 +216,11 @@ Wordless is not meant to be a bloated, all-included tool. This is why we recomme
 
 * [Simple Fields](http://wordpress.org/extend/plugins/simple-fields/): a complete solution to add different types of custom fields to your custom posts. We love Simple fields so much that Wordless embeds a [dedicated helper file](https://github.com/welaika/wordless/blob/master/wordless/helpers/simple_fields_helper.php) just for it;
 * [Options Framework](http://wordpress.org/extend/plugins/options-framework/): makes it easy to include an options panel in any WordPress theme;
-* [Wordmove](https://github.com/welaika/wordmove): a great gem (from yours truly) to automatically mirror local Wordpress installations and DB data back and forth from your local development machine to the remote staging server;
+* [Wordmove](https://github.com/welaika/wordmove): a great gem (from yours truly) to automatically mirror local WordPress installations and DB data back and forth from your local development machine to the remote staging server;
 
 ## Known problems and limitations
 * Wordless has not been tested on Windows machines;
-* From WP 3.2 Wordpress has ceased to support PHP4, and so does Wordless;
+* From WP 3.2 WordPress has ceased to support PHP4, and so does Wordless;
 * Documentation still to be written;
 * The assets static backing for production is still pre-alpha and needs some rewrite (it's rough, but it works);
 * The routing part can be drammaticaly improved to make it more readable and DRY;

--- a/readme.txt
+++ b/readme.txt
@@ -11,10 +11,10 @@ creation, thanks to Sass, Compass, Haml and Coffeescript.
 
 == Description ==
 
-Wordless is an opinionated Wordpress plugin that dramatically speeds up and enhances your custom themes creation. Some of its features are:
+Wordless is an opinionated WordPress plugin that dramatically speeds up and enhances your custom themes creation. Some of its features are:
 
 * A structured, organized and clean [theme organization](https://github.com/welaika/wordless/tree/master/wordless/theme_builder/vanilla_theme) (taken directly from Rails);
-* Ability to create a new theme skeleton directly within the Wordpress backend interface;
+* Ability to create a new theme skeleton directly within the WordPress backend interface;
 * Ability to write PHP code using the beautiful [Haml templating system](http://haml-lang.com/);
 * Ability to write CSS stylesheets using the awesome [Sass syntax](sass-lang.com) and the [Compass framework](http://compass-style.org/);
 * Ability to write [Coffeescript](http://jashkenas.github.com/coffee-script/) instead of the boring, oldish Javascript;
@@ -25,7 +25,7 @@ detailed README, on [Github](https://github.com/welaika/wordless).
 
 == Installation ==
 
-1. Your development machine needs a ruby environment, and the [compass](https://github.com/chriseppstein/compass), [sprockets](https://github.com/sstephenson/sprockets) and [coffee-script](https://github.com/josh/ruby-coffee-script) gem. See below to see how to setup Wordpress on your machine using RVM;
+1. Your development machine needs a ruby environment, and the [compass](https://github.com/chriseppstein/compass), [sprockets](https://github.com/sstephenson/sprockets) and [coffee-script](https://github.com/josh/ruby-coffee-script) gem. See below to see how to setup WordPress on your machine using RVM;
 2. The production machine doesn't need any extra-dependencies, as all the compiled assets automatically get statically backend by Wordless;
 3. [Download the Wordless plugin](https://github.com/welaika/wordless/zipball/master), drop it in the `wp-content/plugins` directory and enable it from the WP "Plugins" section;
 4. Enable the use of nice permalinks from the WP "Settings > Permalink" section. That is, we need the .htaccess file;

--- a/wordless/admin.php
+++ b/wordless/admin.php
@@ -51,7 +51,7 @@ class WordlessAdmin
     $theme_options = array(
       "theme_name" => array(
         "label" => "Theme Name",
-        "description" => "This will be the name displayed inside Wordpress.",
+        "description" => "This will be the name displayed inside WordPress.",
         "default_value" => "Wordless"
       ),
       "theme_path" => array(

--- a/wordless/preprocessors/wordless_preprocessor.php
+++ b/wordless/preprocessors/wordless_preprocessor.php
@@ -158,7 +158,7 @@ class WordlessPreprocessor {
   }
 
   /**
-   * That's the main call of a WordpressPreprocessor subclass.
+   * That's the main call of a WordPressPreprocessor subclass.
    *
    * @attention Must be override by implemented preprocessors.
    *

--- a/wordless/theme_builder/vanilla_theme/config/initializers/custom_post_types.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/custom_post_types.php
@@ -2,7 +2,7 @@
 
 function add_custom_post_types() {
   /*
-   * Create here your custom post types. You can both use the Wordpress register_post_type()
+   * Create here your custom post types. You can both use the WordPress register_post_type()
    * function, or the Wordless new_post_type() helper.
    */
 
@@ -11,7 +11,7 @@ function add_custom_post_types() {
 
 function add_custom_taxonomies() {
   /*
-   * Create here your custom post types. You can both use the Wordpress register_taxonomy()
+   * Create here your custom post types. You can both use the WordPress register_taxonomy()
    * function, or the Wordless new_taxonomy() helper.
    */
 

--- a/wordless/theme_builder/vanilla_theme/config/initializers/hooks.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/hooks.php
@@ -1,6 +1,6 @@
 <?php
 
 /*
- * Place here all your Wordpress add_filter() and add_action() calls.
+ * Place here all your WordPress add_filter() and add_action() calls.
  */
 

--- a/wordless/theme_builder/vanilla_theme/config/initializers/menus.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/menus.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Enable Wordpress menu support uncommenting the line below
+ * Enable WordPress menu support uncommenting the line below
  */
 // add_theme_support('menus');
 

--- a/wordless/theme_builder/vanilla_theme/config/initializers/thumbnail_sizes.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/thumbnail_sizes.php
@@ -2,7 +2,7 @@
 
 function add_thumbnails_support() {
   /*
-   * Enable Wordpress post thumbnail uncommenting the line below and specifing the post types
+   * Enable WordPress post thumbnail uncommenting the line below and specifing the post types
    */
 
   // add_theme_support('post-thumbnails', array('page', 'post'));

--- a/wordless/theme_builder/vanilla_theme/index.php
+++ b/wordless/theme_builder/vanilla_theme/index.php
@@ -2,7 +2,7 @@
 
 /*
  * In this page, you need to setup Wordless routing: you first
- * determine the type of the page using Wordpress conditional tags,
+ * determine the type of the page using WordPress conditional tags,
  * and then delegate the rendering to some particular view using
  * the `render_view()` helper.
  *


### PR DESCRIPTION
WordPress should be spelled with a capital "P". This changes all docs and code comments instances of "Wordpress" to "WordPress".
