### PR TITLE
Replaced depreciated get_bloginfo('siteurl') with home_url().

### DIFF
--- a/wordless.php
+++ b/wordless.php
@@ -211,7 +211,7 @@ class Wordless {
   }
 
   public static function theme_url() {
-    return str_replace(get_bloginfo('siteurl'), '', get_bloginfo('template_url'));
+    return str_replace(home_url(), '', get_bloginfo('template_url'));
   }
 
   public static function join_paths() {


### PR DESCRIPTION
With debug = true, the depreciated function warning breaks a theme.
