### PR TITLE
Updates compass images_dir conf to correct directory

### DIFF
--- a/wordless/preprocessors/compass_preprocessor.php
+++ b/wordless/preprocessors/compass_preprocessor.php
@@ -83,7 +83,7 @@ class CompassPreprocessor extends WordlessPreprocessor {
 
     $config = array(
       "http_path" => Wordless::theme_url(),
-      "images_dir" => "assets/images",
+      "images_dir" => "../assets/images",
       "css_path" => $temp_path,
       "relative_assets" => false,
       "output_style" => ":" . $this->preference("compass.output_style"),


### PR DESCRIPTION
Updates the images_dir compass configuration to the correct path. (images_path points to the tmp/ directory, so you have to go back up one directory to find 'assets/images') This fixes broken compass functions such as image-width, or image-height
