### PR TITLE
Remove unnecessary specification of global namespace

### DIFF
--- a/wordless/process.php
+++ b/wordless/process.php
@@ -23,14 +23,14 @@ class Process
      * @param integer $timeout     The timeout in seconds
      * @param array   $options     An array of options for proc_open
      *
-     * @throws \RuntimeException When proc_open is not installed
+     * @throws RuntimeException When proc_open is not installed
      *
      * @api
      */
     public function __construct($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
     {
         if (!function_exists('proc_open')) {
-            throw new \RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
+            throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
         }
 
         $this->commandline = $commandline;

--- a/wordless/process_builder.php
+++ b/wordless/process_builder.php
@@ -84,7 +84,7 @@ class ProcessBuilder
     public function getProcess()
     {
         if (!count($this->arguments)) {
-            throw new \LogicException('You must add() command arguments before calling getProcess().');
+            throw new LogicException('You must add() command arguments before calling getProcess().');
         }
 
         $options = $this->options;


### PR DESCRIPTION
Namespaces are a feature of PHP 5.3, so removing the "\" allows Wordless to run on older versions of PHP. Unless I missed something, specifying the global namespace is not necessary in this case.
