### PR TITLE
Fix Wordless::compile_assets() to actually output compiled assets instead of blank files

### DIFF
--- a/wordless/wordless.php
+++ b/wordless/wordless.php
@@ -120,11 +120,8 @@ class Wordless {
             $compiled_file_path = preg_replace("/\." . $extension . "$/", ".".$preprocessor->to_extension(), $compiled_file_path);
 
             try {
-              ob_start();
-                $to_process_file_path = preg_replace("/\." . $extension . "$/", "", $file_path);
-                $preprocessor->process_file_with_caching($to_process_file_path, Wordless::theme_temp_path());
-                $compiled_content = ob_get_contents();
-              ob_end_clean();
+              $to_process_file_path = preg_replace("/\." . $extension . "$/", "", $file_path);
+              $compiled_content = $preprocessor->process_file_with_caching($to_process_file_path, Wordless::theme_temp_path());
             } catch(WordlessCompileException $e) {
               echo "Problems compiling $file_path to $compiled_file_path\n\n";
               echo $e;


### PR DESCRIPTION
The preprocessor's process_file_with_caching() method doesn't print anything, it just returns a value. So no need to use the output buffer.
