### PR TITLE
Use file contents as hash seed for cache

### DIFF
--- a/wordless/preprocessors/compass_preprocessor.php
+++ b/wordless/preprocessors/compass_preprocessor.php
@@ -42,7 +42,7 @@ class CompassPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = $file . date("%U", filemtime($file));
+      $hash_seed[] = file_get_contents($file);
     }
     return md5(join($hash_seed));
   }

--- a/wordless/preprocessors/less_preprocessor.php
+++ b/wordless/preprocessors/less_preprocessor.php
@@ -37,7 +37,7 @@ class LessPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = $file . date("%U", filemtime($file));
+      $hash_seed[] = file_get_contents($file);
     }
     return md5(join($hash_seed));
   }

--- a/wordless/preprocessors/sprockets_preprocessor.php
+++ b/wordless/preprocessors/sprockets_preprocessor.php
@@ -38,7 +38,7 @@ class SprocketsPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = $file . date("%U", filemtime($file));
+      $hash_seed[] = file_get_contents($file);
     }
     return md5(join($hash_seed));
   }

--- a/wordless/preprocessors/wordless_preprocessor.php
+++ b/wordless/preprocessors/wordless_preprocessor.php
@@ -93,7 +93,7 @@ class WordlessPreprocessor {
    */
   protected function asset_hash($file_path) {
     // First we get the file content
-    $hash_seed = date("%U", filemtime($file_path));
+    $hash_seed = file_get_contents($file_path);
 
     // Then we attach the preferences
     foreach ($this->preferences_defaults as $pref => $value) {


### PR DESCRIPTION
Hi. Thanks for wordless, I love it.

I had trouble deploying my site to heroku because the filemtime gets set on all the files during deployment which breaks the asset caching. The obvious fix for this is to generate the cache hash from the asset file contents instead of filepath + filemtime, and it seems like that's how this used to work (see https://github.com/welaika/wordless/commit/f136277387e3416e95247495902967f460799db9#commitcomment-1011805) 

Is there a reason why this is a bad idea?

(Possible related issue: #39) 
