### PR TITLE
Remove generator meta tag from theme by default

### DIFF
--- a/wordless/theme_builder/vanilla_theme/config/initializers/hooks.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/hooks.php
@@ -4,3 +4,11 @@
  * Place here all your WordPress add_filter() and add_action() calls.
  */
 
+// Remove the WordPress Generator Meta Tag
+function wordless_remove_generator_filter() { return ''; }
+if (function_exists('add_filter')) {
+  $types = array('html', 'xhtml', 'atom', 'rss2', /*'rdf',*/ 'comment', 'export');
+
+  foreach ($types as $type)
+    add_filter('get_the_generator_' . $type, 'wordless_remove_generator_filter');
+}


### PR DESCRIPTION
WordPress automatically add a generator meta tag in theme head with the specific version of WordPress used by the site. As this is stated everywhere as a high security problem, I think would be better to remove it directly in Wordless.

This snippet remove generator from a whole bunch of display types.

Also, I've added the snippet to the vanilla theme `config/initializers/hooks.php` file, so is easy for the developer to remove/alter this function.
