### PR TITLE
Update readme with additional setup notes

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -53,7 +53,7 @@ Okay, now we can get everything up and running :)
 
 1. The production server doesn't need any extra-dependencies, as all the assets get pre-compiled by Wordless on the development machine and then statically served;
 2. Enable Apache `mod_rewrite` module (`a2enmod rewrite`) and make sure WordPress nice permalinks are enabled under the WP "Settings > Permalinks" section (for example, choose `month and name`);
-3. [Download the Wordless plugin](https://github.com/welaika/wordless/zipball/master), drop it in the `wp-content/plugins` directory and enable it from the WP "Plugins" section;
+3. [Download the Wordless plugin](https://github.com/welaika/wordless/zipball/master), drop it in the `wp-content/plugins` directory (be sure its directory is named 'wordless') and enable it from the WP "Plugins" section;
 4. Create a brand new Wordless theme directly within the WP backend, from the WP "Appearance > New Wordless Theme" section;
 5. Configure the path of your `compass` and `ruby` executables within the `config/initializers/wordless_preferences.php` config file.
 


### PR DESCRIPTION
The plugin directory must be named 'wordless' so the theme builder and/or the wordless gem can leverage it. After downloading and extracting, my wordless directory was named: 'welaika-wordless-358147d'. It took a little while to debug this.
