### PR TITLE
Fix for hashing issue with multiple SASS or CoffeeScript files. Fixes #107, #98, #99

### DIFF
--- a/wordless/preprocessors/compass_preprocessor.php
+++ b/wordless/preprocessors/compass_preprocessor.php
@@ -42,10 +42,10 @@ class CompassPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = file_get_contents($file);
+      $hash_seed[] = $file . date("%U", filemtime($file));
     }
     // Concat original file onto hash seed for uniqueness so each file is unique
-    $hash_seed[] = file_get_contents($file_path);
+    $hash_seed[] = $file_path;
     return md5(join($hash_seed));
   }
 

--- a/wordless/preprocessors/less_preprocessor.php
+++ b/wordless/preprocessors/less_preprocessor.php
@@ -37,10 +37,10 @@ class LessPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = file_get_contents($file);
+      $hash_seed[] = $file . date("%U", filemtime($file));
     }
     // Concat original file onto hash seed for uniqueness so each file is unique
-    $hash_seed[] = file_get_contents($file_path);
+    $hash_seed[] = $file_path;
     return md5(join($hash_seed));
   }
 

--- a/wordless/preprocessors/sprockets_preprocessor.php
+++ b/wordless/preprocessors/sprockets_preprocessor.php
@@ -38,10 +38,10 @@ class SprocketsPreprocessor extends WordlessPreprocessor {
     sort($files);
     $hash_seed = array();
     foreach ($files as $file) {
-      $hash_seed[] = file_get_contents($file);
+      $hash_seed[] = $file . date("%U", filemtime($file));
     }
     // Concat original file onto hash seed for uniqueness so each file is unique
-    $hash_seed[] = file_get_contents($file_path);
+    $hash_seed[] = $file_path;
     return md5(join($hash_seed));
   }
 

--- a/wordless/preprocessors/wordless_preprocessor.php
+++ b/wordless/preprocessors/wordless_preprocessor.php
@@ -92,8 +92,8 @@ class WordlessPreprocessor {
    *
    */
   protected function asset_hash($file_path) {
-    // First we get the file content
-    $hash_seed = file_get_contents($file_path);
+    // First we get the file's modified date
+    $hash_seed = date("%U", filemtime($file_path));
 
     // Then we attach the preferences
     foreach ($this->preferences_defaults as $pref => $value) {


### PR DESCRIPTION
A quick fix to the hashing strategy in the preprocessors - use contents of all files of like type, append current file contents.

This ensures that each root file is recompiled if it or its dependencies change, but each root file has a unique hash. This prevents the hash collisions that caused #107 and #98.

The hashing strategy could be faster for .coffee files (no includes, so this should be simple to fix). It could be smarter for SASS/LESS if we traced down the @import paths but that is considerably more work to save a half a second or two in development.
