### PR TITLE
Updates to is_theme_wordless_compatible() & admin.php:

### DIFF
--- a/wordless/admin.php
+++ b/wordless/admin.php
@@ -29,7 +29,7 @@ class WordlessAdmin
 
   public static function add_notice() {
     // Get a list of missing directories
-    $dirsMissing = Wordless::theme_is_wordless_compatible(true);
+    $dirs_missing = Wordless::theme_is_wordless_compatible(true);
 
     echo '<div class="error"><p>';
     echo sprintf(
@@ -41,7 +41,7 @@ class WordlessAdmin
     );
     echo "</p>";
     echo "<ul>";
-    foreach($dirsMissing as $dir){
+    foreach($dirs_missing as $dir){
       echo "<li>Missing Directory: ".$dir."</li>";
     }
     echo "</ul>";

--- a/wordless/wordless.php
+++ b/wordless/wordless.php
@@ -216,11 +216,18 @@ class Wordless {
    * Checks for required directories when initializing theme. If any are missing, it will return false.
    * If passed `true`, this function will return an array of missing directories.
    *
-   * * @param boolean $returnArray
+   * * @param boolean $return_array
    *   Set true to get a list of missing directories
    *
    */
-  public static function theme_is_wordless_compatible($returnArray = false) {
+  public static function theme_is_wordless_compatible($return_array = false) {
+    // Require wordless_preferences.php in case the user has changed the below paths.
+    $wordless_preferences_path = self::join_paths(self::theme_initializers_path(), "wordless_preferences.php");
+    if(file_exists($wordless_preferences_path)){
+      require_once $wordless_preferences_path;
+    }
+
+    // Scan required directories.
     $required_directories = array(
       self::theme_helpers_path(),
       self::theme_initializers_path(),
@@ -231,17 +238,17 @@ class Wordless {
       self::theme_javascripts_path(),
       self::theme_temp_path()
     );
-    $missingDirectories = array();
+    $missing_directories = array();
     foreach ($required_directories as $dir) {
       if (!file_exists($dir) || !is_dir($dir)) {
-        $missingDirectories[] = $dir;
-        if(!$returnArray)
+        $missing_directories[] = $dir;
+        if(!$return_array)
           return false;
       }
     }
     if(!$returnArray)
       return true;
-    return $missingDirectories;
+    return $missing_directories;
   }
 
   public static function theme_helpers_path() {


### PR DESCRIPTION
Updated to correctly find 'tmp' directory even if it has been moved in wordless_preferences.

Updated error message thrown by is_theme_wordless_compatible to show which directories are missing. This is especially useful on hosts like WPEngine which occasionally automatically delete 'tmp' directories (thus necessitating my last 3 commits).
