### PR TITLE
Fix for Only variables should be passed by reference [PHP requirement]

### DIFF
--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -31,7 +31,8 @@ class RenderHelper {
       $path = Wordless::join_paths(Wordless::theme_views_path(), $filename);
       if (is_file($path)) {
         $template_path = $path;
-        $format = array_pop(explode('.', $path));
+        $arr = explode('.', $path);
+        $format = array_pop($arr);
         break;
       }
     }


### PR DESCRIPTION
This is generated as runtime notice. More info here http://stackoverflow.com/questions/6410061/only-variables-can-be-passed-by-reference-error
