### PR TITLE
add $current_locals global to wl_yield

### DIFF
--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -120,7 +120,7 @@ class RenderHelper {
   * @see render_template()
   */
   function wl_yield() {
-    global $current_view;
+    global $current_view, $current_locals;
     render_template($current_view, $current_locals);
   }
 


### PR DESCRIPTION
The global $current_locals was missing from the wl_yield function, throwing a notice and a warning:
http://i.imgur.com/3LaRIc0.png
