### PR TITLE
use wp default jquery. See long comment

### DIFF
--- a/wordless/theme_builder/vanilla_theme/config/initializers/default_hooks.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/default_hooks.php
@@ -12,7 +12,6 @@ add_action('wp_enqueue_scripts', 'enqueue_stylesheets');
 // This function include jquery and application.js in wp_footer() function
 
 function enqueue_javascripts() {
-  wp_register_script("jquery", '//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js', '', false, true);
   wp_enqueue_script("jquery");
   wp_register_script("application", javascript_url("application"), '', false, true);
   wp_enqueue_script("application");

--- a/wordless/theme_builder/vanilla_theme/theme/assets/javascripts/application.js.coffee
+++ b/wordless/theme_builder/vanilla_theme/theme/assets/javascripts/application.js.coffee
@@ -1,2 +1,2 @@
-$ ->
+jQuery ($) ->
   "Yep, it works!"


### PR DESCRIPTION
This solves 2 problems:
1st we was registering
jquery with the already registered by default
"jquery" handle. 2nd hardcoded jQuery version has
maintanability issues, while WP offers updated
and standard jquery itself.
2nd wp's dafault jquery is loaded in no-conflict
mode, so "$" is not a function by default. I've
modified application.js.coffee in order to have
$ setted up out of the box
