### PR TITLE
the path for resized images was missing a slash, view description

### DIFF
--- a/wordless/helpers/media_helper.php
+++ b/wordless/helpers/media_helper.php
@@ -86,7 +86,7 @@ class MediaHelper {
   function resize_image($src, $width, $height){
     // initializing
     $save_path = Wordless::theme_temp_path();
-    $img_filename = $save_path . '/' . md5($width . 'x' . $height . '_' . basename($src)) . '.jpg';
+    $img_filename = Wordless::join_paths($save_path, md5($width . 'x' . $height . '_' . basename($src)) . '.jpg');
 
     // if file doesn't exists, create it
     if (!file_exists($img_filename)) {


### PR DESCRIPTION
Missing the tmp/ slash, trying to write the image in the theme's root. 

Something like:

/var/www/wordpress/wp-content/themes/theme-name/tmpb0a1f733d586f7cdb7f47381a6b5efd6.jpg

instead:

/var/www/wordpress/wp-content/themes/theme-name/tmp/b0a1f733d586f7cdb7f47381a6b5efd6.jpg 
