### PR TITLE
fix for PHP Warning:  date(): 

### DIFF
--- a/wordless/preprocessors/compass_preprocessor.php
+++ b/wordless/preprocessors/compass_preprocessor.php
@@ -2,11 +2,6 @@
 
 require_once "wordless_preprocessor.php";
 
-if( ! ini_get('date.timezone') )
-{
-   date_default_timezone_set('GMT');
-}
-
 /**
  * Compile Sass files using the `compass` executable.
  *

--- a/wordless/preprocessors/wordless_preprocessor.php
+++ b/wordless/preprocessors/wordless_preprocessor.php
@@ -15,7 +15,20 @@ class WordlessPreprocessor {
   private $deprecated_preferences = array();
 
   public function __construct() {
+    $this->verify_timezone();
     $this->set_preference_default_value("assets.cache_enabled", true);
+  }
+
+  /* Verify setting on date.timezone in your php.ini
+   */
+
+  protected function verify_timezone(){
+    if(ini_get('date.timezone')){
+      date_default_timezone_set(ini_get('date.timezone'));
+    }
+    else{
+      date_default_timezone_set('UTC');
+    }
   }
 
   /**


### PR DESCRIPTION
fix for "PHP Warning:  date(): It is not safe to rely on the system's timezone settings" for assets compile command.
This is the complete warning message:

```
PHP Warning:  date(): It is not safe to rely on the system's timezone settings. 
You are *required* to use the date.timezone setting or the date_default_timezone_set() function. 
In case you used any of those methods and you are still getting this warning, 
you most likely misspelled the timezone identifier. 
We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.
```
