### PR TITLE
Update theme compatibility error message to include 'not'

### DIFF
--- a/locales/template.pot
+++ b/locales/template.pot
@@ -17,7 +17,7 @@ msgstr ""
 #: ../wordless/admin.php:36
 #, php-format
 msgid ""
-"Your current theme does seem to be a Wordless-compatible theme! <a href="
+"Your current theme does not seem to be a Wordless-compatible theme! <a href="
 "\"%2$s\" target=\"_blank\">%1$s</a> (or <a href=\"%4$s\" target=\"_blank\">"
 "%3$s</a>)"
 msgstr ""

--- a/locales/wl-es_ES.po
+++ b/locales/wl-es_ES.po
@@ -17,7 +17,7 @@ msgstr ""
 #: ../wordless/admin.php:36
 #, php-format
 msgid ""
-"Your current theme does seem to be a Wordless-compatible theme! <a href="
+"Your current theme does not seem to be a Wordless-compatible theme! <a href="
 "\"%2$s\" target=\"_blank\">%1$s</a> (or <a href=\"%4$s\" target=\"_blank\">"
 "%3$s</a>)"
 msgstr ""

--- a/locales/wl-it_IT.po
+++ b/locales/wl-it_IT.po
@@ -17,7 +17,7 @@ msgstr ""
 #: ../wordless/admin.php:36
 #, php-format
 msgid ""
-"Your current theme does seem to be a Wordless-compatible theme! <a href="
+"Your current theme does not seem to be a Wordless-compatible theme! <a href="
 "\"%2$s\" target=\"_blank\">%1$s</a> (or <a href=\"%4$s\" target=\"_blank\">"
 "%3$s</a>)"
 msgstr ""

--- a/wordless/admin.php
+++ b/wordless/admin.php
@@ -33,7 +33,7 @@ class WordlessAdmin
 
     echo '<div class="error"><p>';
     echo sprintf(
-      __('Your current theme does seem to be a Wordless-compatible theme! <a href="%2$s" target="_blank">%1$s</a> (or <a href="%4$s" target="_blank">%3$s</a>)', "wl"),
+      __('Your current theme does not seem to be a Wordless-compatible theme! <a href="%2$s" target="_blank">%1$s</a> (or <a href="%4$s" target="_blank">%3$s</a>)', "wl"),
       __('Create a new Wordless theme', "wl"),
       admin_url('themes.php?page=create_wordless_theme'),
       __('learn more about Wordless', "wl"),


### PR DESCRIPTION
I noticed the error messages for theme compatibility didn't contain the word 'not'.  
