### PR TITLE
245 blocks doc

### DIFF
--- a/rtfm/source/_pages/usage/acf_gutenberg_blocks.rst
+++ b/rtfm/source/_pages/usage/acf_gutenberg_blocks.rst
@@ -1,0 +1,55 @@
+.. _Blocks:
+
+ACF Gutenberg Blocks
+====================
+
+Worldess has built-in support for registering new custom gutenberg blocks.
+
+To register a block go to the initializer
+``config/initializers/custom_gutenberg_acf_blocks.php``
+and uncomment the last line in the ``custom_gutenberg_acf_blocks()`` function.
+
+The function is very well self documented:
+
+.. literalinclude:: /../../wordless/theme_builder/vanilla_theme/config/initializers/custom_gutenberg_acf_blocks.php
+    :language: php
+    :caption: config/initializers/custom_gutenberg_acf_blocks.php
+
+Having a block registered this way, you will found it selectable
+in the ACF field group's options.
+
+Said you'll register a block like
+
+.. code-block:: php
+
+    <?php
+
+    create_acf_block('slider', [
+        'title' => 'Slider',
+        'description' => 'Slider',
+        'category' => 'widgets',
+        'icon' => 'admin-comments',
+        'render_callback' => '_acf_block_render_callback',
+        'keywords' => [ 'image', 'slider' ]
+    ]);
+
+Wordless will search for two partials to render:
+
+* ``views/blocks/admin/_slider.html.pug``
+* ``views/blocks/_slider.html.pug``
+
+The first one is used to render the block in the backend Gutenberg's
+interface. If absent, then the second will be used.
+
+You will be obviously free to render the block anywhere in your
+front-end template, since it's a simple partial:
+
+.. code-block:: jade
+
+    render_partial('blocks/slider')
+
+.. note::
+
+    You can change the path where the partial is searched for
+    by using the :ref:`wordless_acf_gutenberg_blocks_views_path`
+    filter

--- a/rtfm/source/_pages/usage/anatomy.rst
+++ b/rtfm/source/_pages/usage/anatomy.rst
@@ -305,6 +305,7 @@ one with a specific target:
 
   config/initializers
   ├──── backend.php
+  ├──── custom_gutenberg_acf_blocks.php
   ├──── custom_post_types.php
   ├──── default_hooks.php
   ├──── hooks.php
@@ -314,6 +315,8 @@ one with a specific target:
   ├──── thumbnail_sizes.php
 
 - **backend**: remove backend components such as widgets, update messages, etc
+- **custom_gutenbers_acf_blocks**: Wordless has built-in support to ACF/Gutenberg blocks. Read more
+  at :ref:`Blocks`
 - **custom_post_types**: well... if you need to manage taxonomies, this is the
   place to be
 - **default_hooks**: these are used by wordless's default behaviours; tweak them

--- a/rtfm/source/_pages/usage/filters.rst
+++ b/rtfm/source/_pages/usage/filters.rst
@@ -28,3 +28,35 @@ wordless_pug_configuration
 
         return $options;
     }
+
+wordless_acf_gutenberg_blocks_views_path
+########################################
+
+.. literalinclude:: /../../wordless/helpers/acf_gutenberg_block_helper.php
+    :emphasize-lines: 5
+    :language: php
+    :caption: wordless/helpers/acf_gutenberg_block_helper.php
+    :lineno-start: 48
+    :lines: 48-66
+
+**Usage example**
+
+.. code-block:: php
+
+    <?php
+    add_filter('wordless_acf_gutenberg_blocks_views_path', 'custom_blocks_path', 10, 1);
+
+    function custom_blocks_path(string $path): string {
+        return 'custom_path';
+    }
+
+This way Wordless will search for blocks' partials in
+``views/custom_path/block_name.html.pug``
+so you can use ``render_partial('custom_path/block_name')`` to render them in your
+template.
+
+The default path is ``blocks/``.
+
+.. note::
+
+    The path will be always relative to ``views/`` folder

--- a/wordless/helpers/acf_gutenberg_block_helper.php
+++ b/wordless/helpers/acf_gutenberg_block_helper.php
@@ -48,16 +48,19 @@ class AcfGutenbergBlockHelper {
   function _acf_block_render_callback( $block ) {
     $slug = str_replace('acf/', '', $block['name']);
 
-    if ( file_exists( get_theme_file_path("/theme/views/blocks/admin/_{$slug}.pug") ) ) {
-        $admin_partial = "blocks/admin/{$slug}";
+    // The filter must return a string, representing a folder relative to `views/`
+    $blocks_folder = apply_filters('wordless_acf_gutenberg_blocks_views_path', 'blocks/');
+
+    if ( file_exists( get_theme_file_path("/views/{$blocks_folder}/admin/_{$slug}.pug") ) ) {
+        $admin_partial = "{$blocks_folder}/admin/{$slug}";
     } else {
-        $admin_partial = "blocks/{$slug}";
+        $admin_partial = "{$blocks_folder}/{$slug}";
     }
 
     if ( is_admin() ) {
         render_partial($admin_partial);
     } else {
-        render_partial("blocks/{$slug}");
+        render_partial("{$blocks_folder}/{$slug}");
     }
   }
 }

--- a/wordless/theme_builder/vanilla_theme/config/initializers/custom_gutenberg_acf_blocks.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/custom_gutenberg_acf_blocks.php
@@ -3,12 +3,18 @@
 function custom_gutenberg_acf_blocks() {
     /*
      * Create Gutenberg Block with Advanced Custom Fields.
+     * This function is a wrapper around the `acf_register_block` function. Read more about it at
+     * https://www.advancedcustomfields.com/blog/acf-5-8-introducing-acf-blocks-for-gutenberg/
+     *
      * Note: You can reapeat it for as many blocks as you have to create
+     *
      * Params:
-     *     mandatory:
-     *.       block name
-     *     optional:
-              array of params:
+     *     string, mandatory:
+     *         "block name"; if you use spaces in the name, they'll get converted to `-`
+                where needed. You'll need to name your partial the same as this param.
+                E.g.: having "Home Page" Wordless will search for `views/blocks/home-page.html.pug`
+                partial
+     *     array, optional:
      *        title           => if blank use $block_name
      *        description     => if blank use $block_name
      *        category        => if blank use 'formatting'.
@@ -18,13 +24,24 @@ function custom_gutenberg_acf_blocks() {
                                     'widgets',
                                     'layout',
                                     'embed'.
-     *        icon            => if blank use 'smiley'
-     *        render_callback => if blank use '_acf_block_render_callback',
+     *        icon            => if blank use 'smiley'; you can use any icon name from
+     *                           https://developer.wordpress.org/resource/dashicons/
+     *        render_callback => if blank use the default '_acf_block_render_callback',
      *        keywords        => if blank use ['acf', 'block']
      *
      */
 
-    // create_acf_block('slider', ['title' => 'Slider', 'description' => 'Slider', 'category' => 'widgets', 'icon' => 'admin-comments', 'render_callback' => '_acf_block_render_callback', 'keywords' => [ 'image', 'slider' ]]);
+    /* Example:
+    create_acf_block('slider', [
+        'title' => 'Slider',
+        'description' => 'Slider',
+        'category' => 'widgets',
+        'icon' => 'admin-comments',
+        'render_callback' => '_acf_block_render_callback',
+        'keywords' => [ 'image', 'slider' ]
+    ]);
+    */
+
     // create_acf_block('slider', array());
 }
 


### PR DESCRIPTION
* fix a bug in `wordless/helpers/acf_gutenberg_block_helper.php`: the `theme/` folder does not exist anymore in Wordless 3
* added a hook to allow blocks' path modification from within the theme
* improved `custom_gutenberg_acf_blocks()`'s documentation
* added ACf/Gutenberg support to the official documentation (readthedocs)