### PR TITLE
deleted WP_ENV=test from test:db:snapshot command in test:db:setup

### DIFF
--- a/wordless/theme_builder/vanilla_theme/package.json
+++ b/wordless/theme_builder/vanilla_theme/package.json
@@ -24,7 +24,7 @@
     "test:db:create": "WP_ENV=test wp db create",
     "test:db:drop": "WP_ENV=test wp db drop",
     "test:db:snapshot": "mv tests/_data/dump.sql tests/_data/dump_$(date +%s).sql; wp db export tests/_data/dump.sql",
-    "test:db:setup": "WP_ENV=test yarn test:db:drop; WP_ENV=test yarn test:db:create; WP_ENV=test yarn test:db:snapshot",
+    "test:db:setup": "WP_ENV=test yarn test:db:drop; WP_ENV=test yarn test:db:create; yarn test:db:snapshot",
     "test:setup": "wp wordless theme setup_test_suite && yarn test:db:setup && composer install && php ./vendor/bin/codecept build",
     "test:server": "npx nf start --procfile Procfile.testing --env .env.testing",
     "test": "vendor/bin/codecept run acceptance",


### PR DESCRIPTION
Ti propongo questa motifica, se ritieni che possa essere utile ☺️

Ho notato che i problemi relativi al lancio dei test, sono risolvibili eliminando in `WP_ENV=test` dal comando `yarn test:db:snapshot` in `test:db:setup`. 
Come gia' avevamo visto assieme, non veniva creato il db per i test, o meglio, non veniva popolato al setup.


