### PR TITLE
Add support for responsive embeds by default

### DIFF
--- a/wordless/theme_builder/vanilla_theme/config/initializers/default_hooks.php
+++ b/wordless/theme_builder/vanilla_theme/config/initializers/default_hooks.php
@@ -18,3 +18,12 @@ function enqueue_javascripts() {
 }
 
 add_action('wp_enqueue_scripts', 'enqueue_javascripts');
+
+// Load theme supports
+// See http://developer.wordpress.org/reference/functions/add_theme_support/
+// for more theme supports you'd like to add. `reponsive-embeds` is on by
+// default.
+function wordless_theme_supports() {
+  add_theme_support('responsive-embeds');
+}
+add_action('after_setup_theme', 'wordless_theme_supports');


### PR DESCRIPTION
See https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#responsive-embedded-content
for an explanation of the functionality.

Now it's on by default in wordless.