### PR TITLE
Call `renderAndWriteFile` w/o Optimizer even in prod

### DIFF
--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -114,7 +114,8 @@ class RenderHelper {
                             if (file_exists($staticPath)) {
                                 include $staticPath;
                             } else {
-                                \Pug\Optimizer::call('renderAndWriteFile', [$template_path, $staticPath, $locals], WordlessPugOptions::get_options());
+                                \Pug\Facade::setOptions(WordlessPugOptions::get_options());
+                                \Pug\Facade::renderAndWriteFile($template_path, $staticPath, $locals);
                                 include $staticPath;
                             }
                         } else {


### PR DESCRIPTION
Given we haven't performance drawbacks because we
call the compilation ONLY if the static file isn't
present, this solves some scenarios where, using
Optimizer, the compilation could not be called, thus
the template not rendered