### PR TITLE
Gitignore specifically node_modules/ folder

### DIFF
--- a/wordless/theme_builder/vanilla_theme/.gitignore
+++ b/wordless/theme_builder/vanilla_theme/.gitignore
@@ -4,5 +4,5 @@ dist/*/*
 !dist/*/.gitkeep
 !dist/fonts
 .DS_Store
-node_modules
+node_modules/
 vendor/


### PR DESCRIPTION
Ignoring the `node_modules/` folder is more correct than generically ignoring `node_modules`