### PR TITLE
Fix bug in render_static() render helper

### DIFF
--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -169,7 +169,7 @@ class RenderHelper {
             render_error("Static rendering only available for PUG templates", "<strong>Ouch!!</strong> It seems you required a <code>render_static</code> for a PHP template, but this render method is supported only for PUG. Use <code>render_partial</code> or <code>render_template</code> instead.");
         }
 
-        render_template($name, $locals = array(), $static = true);
+        render_template($name, $locals, $static = true);
     }
 
     /**


### PR DESCRIPTION
The function have to just prox $locals variable
to the wrapped render_template() function.
Previously it was blanking the variable value
with an empty array