### PR TITLE
Render helper render_template, ensure_dir function bug

### DIFF
--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -248,7 +248,11 @@ class RenderHelper {
 
     private function ensure_dir($dir) {
 
-        if (!file_exists($dir)) {
+        $files_count = 0;
+
+        if ( file_exists( $dir ) ) {
+            $files_count = preg_grep('/(.*).(php|txt)$/', scandir( $dir ) );
+        } else {
             mkdir($dir, 0770);
         }
 
@@ -256,7 +260,7 @@ class RenderHelper {
             chmod($dir, 0770);
         }
 
-        if (is_writable($dir)) {
+        if ( is_writable( $dir ) || count ( $files_count ) > 0 ) {
             return true;
         } else {
             return false;

--- a/wordless/helpers/render_helper.php
+++ b/wordless/helpers/render_helper.php
@@ -107,6 +107,8 @@ class RenderHelper {
                         $bypass_static = 'false'; // default value
                     }
 
+                    $env = apply_filters( 'wordless_environment', $env );
+
                     if ( in_array( $env, array('staging', 'production') ) ) {
                         if (true === $static && 'false' == strtolower($bypass_static)) {
                             $staticPath = $this->static_path($name, $locals);


### PR DESCRIPTION
In **render_helper.php** file in function error was identified:  **Ouch!! It seems that the /var/www/wp-content/themes/<<theme>>/tmp**

**ensure_dir** function sometimes cannot override the tmp folder permission to writeable, some server forbid the chmod action. Hence we compile our files via CLI during CI build process, this generates files in tmp DIR. Now I have corrected version of ensure_dir function test in our environment to check both compiled files in tmp and also create tmp if didn't exist this applies for both scenario.

 Secondly we have filter '**wordless_environment'** to override the environment.